### PR TITLE
Return 0 on success in getvcp/setvcp

### DIFF
--- a/winddcutil/winddcutil.cpp
+++ b/winddcutil/winddcutil.cpp
@@ -121,14 +121,14 @@ int getVcp(std::vector<std::string> args) {
 	bool success = GetVCPFeatureAndVCPFeatureReply(physicalMonitorHandle, vcpCode, NULL, &currentValue, NULL);
 	if (!success) {
 		std::cerr << "Failed to get the vcp code value" << std::endl;
-		return success;
+		return 1;
 	}
 
 	std::stringstream ss;
 	ss << std::hex << currentValue;
 	std::cout << "VCP " << args[1] << " " << ss.str() << std::endl;
 
-	return success;
+	return 0;
 }
 
 int setVcp(std::vector<std::string> args) {
@@ -156,9 +156,11 @@ int setVcp(std::vector<std::string> args) {
 	}
 
 	bool success = SetVCPFeature(physicalMonitors[displayId].hPhysicalMonitor, vcpCode, newValue);
-	if (!success)
+	if (!success) {
 		std::cerr << "Failed to set vcp feature" << std::endl;
-	return success;
+		return 1;
+	}
+	return 0;
 }
 
 std::unordered_map<std::string, std::function<int(std::vector<std::string>)>> commands


### PR DESCRIPTION
The `getVcp` and `setVcp` methods return the boolean results of the underlying API calls, which causes the program to exit 1 on success and 0 on failure. Typically 0 indicates success, so here's a small change to return the appropriate exit codes.

Due to the encoding of the `.cpp` file, git seems to think it's binary, so unfortunately the diff doesn't appear correctly. I've reproduced the diff below for easier review:

```diff
diff --git a/winddcutil/winddcutil.cpp b/winddcutil/winddcutil.cpp
index 6042067..9bc33ec 100644
--- a/winddcutil/winddcutil.cpp
+++ b/winddcutil/winddcutil.cpp
@@ -121,14 +121,14 @@ int getVcp(std::vector<std::string> args) {
        bool success = GetVCPFeatureAndVCPFeatureReply(physicalMonitorHandle, vcpCode, NULL, &currentValue, NULL);
        if (!success) {
                std::cerr << "Failed to get the vcp code value" << std::endl;
-               return success;
+               return 1;^M
        }

        std::stringstream ss;
        ss << std::hex << currentValue;
        std::cout << "VCP " << args[1] << " " << ss.str() << std::endl;

-       return success;
+       return 0;^M
 }

 int setVcp(std::vector<std::string> args) {
@@ -156,9 +156,11 @@ int setVcp(std::vector<std::string> args) {
        }

        bool success = SetVCPFeature(physicalMonitors[displayId].hPhysicalMonitor, vcpCode, newValue);
-       if (!success)
+       if (!success) {^M
                std::cerr << "Failed to set vcp feature" << std::endl;
-       return success;
+               return 1;^M
+       }^M
+       return 0;^M
 }

 std::unordered_map<std::string, std::function<int(std::vector<std::string>)>> commands
```